### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "gulp-sourcemaps": "^2.6.4"
   },
   "dependencies": {
-    "jquery": "^3.3.1",
-    "npm": "^6.4.1"
+    "jquery": "^3.3.1"
   },
   "keywords": [
     "DHC",


### PR DESCRIPTION

Hello waynestedman!

It seems like you have npm as one of your (dev-) dependency in coq10.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
